### PR TITLE
Move Ruff to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 aiohttp = { version = "^3.9.1", optional = true }
-black = "^23.12.1"
 mashumaro = "^3.11"
 python = "^3.9"
 
@@ -16,6 +15,7 @@ python = "^3.9"
 aiohttp = ["aiohttp"]
 
 [tool.poetry.dev-dependencies]
+black = "^23.12.1"
 flake8 = "^6.1.0"
 ruff = "^0.1.9"
 isort = "^5.13.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,13 @@ aiohttp = { version = "^3.9.1", optional = true }
 black = "^23.12.1"
 mashumaro = "^3.11"
 python = "^3.9"
-ruff = "^0.1.9"
 
 [tool.poetry.extras]
 aiohttp = ["aiohttp"]
 
 [tool.poetry.dev-dependencies]
 flake8 = "^6.1.0"
+ruff = "^0.1.9"
 isort = "^5.13.2"
 mypy = "^1.8.0"
 pytest = "^7.4.3"


### PR DESCRIPTION
With ruff in the normal dependencies, it will be installed during HA setup, breaking builds now.

So if we could get a release quickly after this PR and we can bump it that'd be great

Fixes #5