### PR TITLE
Swap light and steamer in CONFIG_CODE_TEXTS

### DIFF
--- a/huum/const.py
+++ b/huum/const.py
@@ -19,8 +19,8 @@ STATUS_CODE_TEXTS: Dict[int, str] = {
 }
 
 CONFIG_CODE_TEXTS: Dict[int, str] = {
-    1: "Configured to user light system",
-    2: "Configured to use steamer system",
+    1: "Configured to use steamer system",
+    2: "Configured to user light system",
     3: "Configured to use both light and steamer systems",
 }
 


### PR DESCRIPTION
Looking at my own UKU Wi-Fi sauna (I have both a light and steamer) these codes should be swapped.