### PR TITLE
Use correct max_temp in range

### DIFF
--- a/huum/huum.py
+++ b/huum/huum.py
@@ -95,7 +95,7 @@ class Huum:
         Returns:
             A `HuumStatusResponse` from the Huum API
         """
-        if temperature not in range(self.min_temp, self.max_temp):
+        if temperature not in range(self.min_temp, self.max_temp + 1):
             raise ValueError(
                 f"Temperature '{temperature}' must be between {self.min_temp}-{self.max_temp}"
             )


### PR DESCRIPTION
The stop in `range()` is exclusive. To be able to set the sauna to 110 we need to increase by one.