### PR TITLE
Implement new UKU firmware humidity thresholds

### DIFF
--- a/huum/const.py
+++ b/huum/const.py
@@ -27,7 +27,7 @@ CONFIG_CODE_TEXTS: Dict[int, str] = {
 STEAMER_CODE_TEXTS: Dict[int, str] = {1: "No water in steamer, steamer system not allowed to start"}
 
 # Taken from UKU 4.2 manual
-HUMIDITY_TRESHOLDS = [
+HUMIDITY_THRESHOLDS = [
     (45, 90),
     (50, 55),
     (55, 45),

--- a/huum/const.py
+++ b/huum/const.py
@@ -25,3 +25,19 @@ CONFIG_CODE_TEXTS: Dict[int, str] = {
 }
 
 STEAMER_CODE_TEXTS: Dict[int, str] = {1: "No water in steamer, steamer system not allowed to start"}
+
+# Taken from UKU 4.2 manual
+HUMIDITY_TRESHOLDS = [
+    (45, 90),
+    (50, 55),
+    (55, 45),
+    (60, 40),
+    (65, 35),
+    (70, 30),
+    (75, 25),
+    (80, 20),
+    (85, 15),
+    (90, 10),
+]
+MIN_TEMP = 40
+MAX_TEMP = 110

--- a/huum/huum.py
+++ b/huum/huum.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 import aiohttp
 from aiohttp import ClientResponse
 
-from huum.const import HUMIDITY_TRESHOLDS, MAX_TEMP, MIN_TEMP
+from huum.const import HUMIDITY_THRESHOLDS, MAX_TEMP, MIN_TEMP
 from huum.exceptions import (
     BadRequest,
     Forbidden,
@@ -187,7 +187,7 @@ class Huum:
         await self.session.close()
 
     def get_max_humidity(self, temperature: int) -> int:
-        for treshold_temp, max_humidity in HUMIDITY_TRESHOLDS:
-            if temperature <= treshold_temp:
+        for threshold_temp, max_humidity in HUMIDITY_THRESHOLDS:
+            if temperature <= threshold_temp:
                 return max_humidity
         return 0

--- a/huum/huum.py
+++ b/huum/huum.py
@@ -4,6 +4,7 @@ from urllib.parse import urljoin
 import aiohttp
 from aiohttp import ClientResponse
 
+from huum.const import HUMIDITY_TRESHOLDS, MAX_TEMP, MIN_TEMP
 from huum.exceptions import (
     BadRequest,
     Forbidden,
@@ -33,9 +34,6 @@ class Huum:
         # Turn on the sauna
         huum.turn_on(80)
     """
-
-    min_temp = 40
-    max_temp = 110
 
     session: aiohttp.ClientSession
 
@@ -98,15 +96,16 @@ class Huum:
         Returns:
             A `HuumStatusResponse` from the Huum API
         """
-        if temperature not in range(self.min_temp, self.max_temp + 1):
-            raise ValueError(
-                f"Temperature '{temperature}' must be between {self.min_temp}-{self.max_temp}"
-            )
+        if temperature not in range(MIN_TEMP, MAX_TEMP + 1):
+            raise ValueError(f"Temperature '{temperature}' must be between {MIN_TEMP}-{MAX_TEMP}")
         data = {"targetTemperature": temperature}
 
         if humidity is not None:
-            if humidity not in range(0, 11):
-                raise ValueError(f"Humidity '{humidity}' must be between 0-10")
+            max_humidity = self.get_max_humidity(temperature)
+            if humidity > max_humidity:
+                raise ValueError(
+                    f"Humidity '{humidity}' cannot be higher than {max_humidity} at temperature {temperature}"
+                )
             data["humidity"] = humidity
 
         if not safety_override:
@@ -186,3 +185,9 @@ class Huum:
 
     async def close_session(self) -> None:
         await self.session.close()
+
+    def get_max_humidity(self, temperature: int) -> int:
+        for treshold_temp, max_humidity in HUMIDITY_TRESHOLDS:
+            if temperature <= treshold_temp:
+                return max_humidity
+        return 0

--- a/tests/test_huum.py
+++ b/tests/test_huum.py
@@ -68,7 +68,7 @@ async def test_bad_humidity_value(mock_request: Any) -> None:
     huum = Huum("test", "test")
     await huum.open_session()
     with pytest.raises(ValueError):
-        await huum.turn_on(temperature=40, humidity=11)
+        await huum.turn_on(temperature=90, humidity=11)
 
 
 @pytest.mark.asyncio
@@ -100,19 +100,19 @@ async def test_humidity_turn_on(mock_request: Any) -> None:
         "temperature": 80,
         "maxHeatingTime": 180,
         "saunaName": "test",
-        "humidity": 5,
+        "humidity": 20,
     }
     mock_request.return_value = MockResponse(response, 200)
 
     huum = Huum("test", "test")
     await huum.open_session()
-    result_turn_on = await huum.turn_on(temperature=80, humidity=5)
+    result_turn_on = await huum.turn_on(temperature=80, humidity=20)
 
     mock_request.assert_called_with(
         "POST",
         "https://sauna.huum.eu/action/home/start",
         data=None,
         auth=ANY,
-        json={"targetTemperature": 80, "humidity": 5},
+        json={"targetTemperature": 80, "humidity": 20},
     )
-    assert result_turn_on.humidity == 5
+    assert result_turn_on.humidity == 20

--- a/tests/test_huum.py
+++ b/tests/test_huum.py
@@ -116,3 +116,10 @@ async def test_humidity_turn_on(mock_request: Any) -> None:
         json={"targetTemperature": 80, "humidity": 20},
     )
     assert result_turn_on.humidity == 20
+
+
+def test_max_humidity() -> None:
+    huum = Huum("test", "test")
+    assert huum.get_max_humidity(90) == 10
+    assert huum.get_max_humidity(40) == 90
+    assert huum.get_max_humidity(100) == 0


### PR DESCRIPTION
Also added a helper function to check the max humidity for a temperature. Useful in Home Assistant for example.

The API itself will not properly handle these thresholds. It will either accept the request but set humidity to 0 silently. Or, when a humidity is not explicitly supplied but the current value is higher than the new temperature threshold, it will keep the current humidity value although the sauna controller itself lowered it. 